### PR TITLE
Check whether we have a location header before trying to `.substring()` on it.

### DIFF
--- a/src/stereotype_client.js
+++ b/src/stereotype_client.js
@@ -246,8 +246,7 @@ class StereotypeClient {
                 // the `+ 1` is for the leading `/`:
                 let preStringLen = conf.VERSION.length + conf.MATERIALIZATIONS.length + 1;
                 resolve(res.headers.location.substring(preStringLen));
-              } else if (preferAsync && res.headers && res.headers['access-control-expose-headers'] &&
-                res.headers['access-control-expose-headers'].include('Preference-Applied')) {
+              } else if (res.status == 202) { // async
                 resolve(res.headers.location);
               } else {
                 resolve(res.text);

--- a/src/stereotype_client.js
+++ b/src/stereotype_client.js
@@ -246,7 +246,8 @@ class StereotypeClient {
                 // the `+ 1` is for the leading `/`:
                 let preStringLen = conf.VERSION.length + conf.MATERIALIZATIONS.length + 1;
                 resolve(res.headers.location.substring(preStringLen));
-              } else if (preferAsync && res.headers['access-control-expose-headers'].include('Preference-Applied')) {
+              } else if (preferAsync && res.headers && res.headers['access-control-expose-headers'] &&
+                res.headers['access-control-expose-headers'].include('Preference-Applied')) {
                 resolve(res.headers.location);
               } else {
                 resolve(res.text);

--- a/src/stereotype_client.js
+++ b/src/stereotype_client.js
@@ -242,7 +242,7 @@ class StereotypeClient {
             (res) => {
               subsegment.addAnnotation('ResponseCode', res.status);
               subsegment.close();
-              if (getMaterializationId) {
+              if (getMaterializationId && res.headers && res.headers.location) {
                 // the `+ 1` is for the leading `/`:
                 let preStringLen = conf.VERSION.length + conf.MATERIALIZATIONS.length + 1;
                 resolve(res.headers.location.substring(preStringLen));


### PR DESCRIPTION
I noticed we sometimes get an odd error about calling substring on undefined. It turned out that we don't always have a location header on successful materialisation. We either need to ensure that we do or (and/or) check if we have it as I've done in this PR.