### PR TITLE
Get parameters starts with ?

### DIFF
--- a/src/stereotype_client.js
+++ b/src/stereotype_client.js
@@ -93,7 +93,7 @@ class StereotypeClient {
         subsegment.addAnnotation('REST Action', 'GET');
 
         request
-          .get(conf.TEMPLATES_URL + (skipCache ? `&skip_cache=${Date.now()}` : ''))
+          .get(conf.TEMPLATES_URL + (skipCache ? `?skip_cache=${Date.now()}` : ''))
           .set('Authorization', 'Bearer ' + self.accessToken)
           .then(
             (res) => {
@@ -132,7 +132,7 @@ class StereotypeClient {
         subsegment.addAnnotation('Template', idTemplate);
 
         request
-          .get(conf.TEMPLATES_URL + idTemplate + (skipCache ? `&skip_cache=${Date.now()}` : ''))
+          .get(conf.TEMPLATES_URL + idTemplate + (skipCache ? `?skip_cache=${Date.now()}` : ''))
           .set('Authorization', 'Bearer ' + self.accessToken)
           .then(
             (res) => {


### PR DESCRIPTION
The gets parameters where starting with & instead of ?

Due this, the skip cache parameter for listTemplates and getTemplate was not working.