### PR TITLE
Fix 400 error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "stereotype-client",
-	"version": "1.2.17",
+	"version": "1.2.22",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stereotype-client",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "A simple client for Cimpress' Stereotype service.",
   "scripts": {
     "test": "grunt test",

--- a/src/stereotype_client.js
+++ b/src/stereotype_client.js
@@ -441,7 +441,7 @@ class StereotypeClient {
               resolve(res.text);
             },
             (err) => {
-              let isTimeoutError = (err) => err.response.body.findIndex((e) => e.expandedMessage.includes('ESOCKETTIMEDOUT')) !== -1;
+              let isTimeoutError = (err) => err.response.text.includes('ESOCKETTIMEDOUT');
 
               subsegment.addAnnotation('ResponseCode', err.status);
               subsegment.addAnnotation('UnableToExpandPropertyBag: ' + err.message);


### PR DESCRIPTION
When a bad request is sent to Stereotype the error handler was throwing an exception.

`Uncaught (in promise) TypeError: Cannot read property 'findIndex' of null
    at isTimeoutError (stereotype_client.js:480)
    at stereotype_client.js:488`